### PR TITLE
Modified Tint2 to blend better with Numix Frost

### DIFF
--- a/home/user/.config/tint2/tint2rc
+++ b/home/user/.config/tint2/tint2rc
@@ -7,8 +7,8 @@
 #---------------------------------------------
 rounded = 0
 border_width = 1
-background_color = #a0a0a0 60
-border_color = #ffffff 18
+background_color = #2d2d2d 60
+border_color = #2d2d2d 18
 
 rounded = 0
 border_width = 0


### PR DESCRIPTION
I modified the top Tint2 panel to better blend with the Numix Frost theme design by changing the light background and border of the panel to a darker theme.

Before:
![antergos-openbox-tint2-bug-1](https://cloud.githubusercontent.com/assets/1056731/21277833/d96ed886-c39d-11e6-9c9c-f74b28c2bc26.png)

After:
![antergos-openbox-tint2-bug](https://cloud.githubusercontent.com/assets/1056731/21277838/dd08bc6e-c39d-11e6-95d5-4f6cc209a9b6.png)
